### PR TITLE
Fix package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ cm.update('notebook', {"load_extensions": {"pugme": True}})
 
 Voila!  You should now see the pug icon in the notebook toolbar.
 
-**Note: This has only been tested with jupyter 4.0.6.**
+**Note: This has only been tested with notebook 4.0.6.**


### PR DESCRIPTION
Jupyter is the metapackage: https://pypi.python.org/pypi/jupyter still inversion 1.0.0
notebook is the actual package that run the notebook.

`jupyter --version`, give the version of `jupyter_core`  and the version you are probably looking for is the one of `jupyter notebook --version`

Yes I know it is confusing.
